### PR TITLE
parking: ensure Reactor is initialized when creating a Parker

### DIFF
--- a/src/parking.rs
+++ b/src/parking.rs
@@ -59,6 +59,8 @@ impl Parker {
             },
         };
         PARKER_COUNT.fetch_add(1, Ordering::SeqCst);
+        // We use the Reactor in Drop, so ensure it's properly initialized since it's lazy
+        Reactor::get();
         parker
     }
 


### PR DESCRIPTION
Alternative to https://github.com/async-rs/async-std/pull/836/commits/d4572c794d2b1c38d3acaf1e327ff370e6c7b4d1

I guess it makes sense to do that here?