### PR TITLE
fail fast on `io::ErrorKind::NotConnected`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1222,6 +1222,9 @@ impl Async<UnixStream> {
         // The stream becomes writable when connected.
         stream.writable().await?;
 
+        // On Linux, it appears the socket may become writable even when connecting fails, so we
+        // must do an extra check here and see if the peer address is retrievable.
+        stream.get_ref().peer_addr()?;
         Ok(stream)
     }
 


### PR DESCRIPTION
Maybe a comment would be useful? Something like "Workaround to check if there was an error while connecting."?