### PR TITLE
add AnAsync{,Ext} traits to reuse {read,write}_with{,_mut}

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["asynchronous", "network-programming", "os"]
 readme = "README.md"
 
 [dependencies]
+async-trait = "0.1"
 cfg-if = "0.1.10"
 concurrent-queue = "1.2.0"
 fastrand = "1.3.4"

--- a/examples/linux-inotify.rs
+++ b/examples/linux-inotify.rs
@@ -10,7 +10,7 @@
 fn main() -> std::io::Result<()> {
     use std::ffi::OsString;
 
-    use async_io::Async;
+    use async_io::{Async, AnAsync, AnAsyncExt};
     use futures_lite::*;
     use inotify::{EventMask, Inotify, WatchMask};
 

--- a/examples/linux-timerfd.rs
+++ b/examples/linux-timerfd.rs
@@ -11,7 +11,7 @@ fn main() -> std::io::Result<()> {
     use std::os::unix::io::AsRawFd;
     use std::time::{Duration, Instant};
 
-    use async_io::Async;
+    use async_io::{Async, AnAsyncExt};
     use futures_lite::*;
     use timerfd::{SetTimeFlags, TimerFd, TimerState};
 

--- a/examples/windows-uds.rs
+++ b/examples/windows-uds.rs
@@ -10,7 +10,7 @@
 fn main() -> std::io::Result<()> {
     use std::path::PathBuf;
 
-    use async_io::Async;
+    use async_io::{Async, AnAsync, AnAsyncExt};
     use blocking::Unblock;
     use futures_lite::*;
     use tempfile::tempdir;

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
-use async_io::{Async, Timer};
+use async_io::{Async, AnAsync, Timer};
 use futures_lite::*;
 #[cfg(unix)]
 use tempfile::tempdir;


### PR DESCRIPTION
This lets me dedupe some more code from rs-bwlim - specifically https://github.com/infinity0/rs-bwlim/commit/163717455b3d9cbd34ea4eb175da11601a486b16

However it is less trivial than #22 - we depend on an unstable nightly-only scary feature of rust - `generic_associated_types`. Also we need `async_trait` which itself a temporary thing, pending much-future advances in rust. So I can totally understand if you don't want it in just yet.

I tried various other strategies but couldn't get them working. The main problem being that due to instance coherence rules, rust does not let you `impl ForeignTrait for T where T: LocalTrait` but this is ideally what we want to do, i.e. `impl AsyncRead for T where T: AnAsyncExt`. So the current PR is the best I came up with.
