### PR TITLE
remove drop(self) when react

### DIFF
--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -500,9 +500,6 @@ impl ReactorLock<'_> {
             Err(err) => Err(err),
         };
 
-        // Drop the lock before waking.
-        drop(self);
-
         // Wake up ready tasks.
         log::trace!("react: {} ready wakers", wakers.len());
         for waker in wakers {


### PR DESCRIPTION
calls to `std::mem::drop` with a reference instead of an owned value. Dropping a reference does nothing.