### PR TITLE
Less boxing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -853,12 +853,13 @@ impl Async<TcpListener> {
     ///
     /// ```no_run
     /// use async_io::Async;
-    /// use futures_lite::stream::StreamExt;
+    /// use futures_lite::{pin, stream::StreamExt};
     /// use std::net::TcpListener;
     ///
     /// # futures_lite::future::block_on(async {
     /// let listener = Async::<TcpListener>::bind(([127, 0, 0, 1], 8000))?;
-    /// let mut incoming = listener.incoming();
+    /// let incoming = listener.incoming();
+    /// pin!(incoming);
     ///
     /// while let Some(stream) = incoming.next().await {
     ///     let stream = stream?;
@@ -866,11 +867,11 @@ impl Async<TcpListener> {
     /// }
     /// # std::io::Result::Ok(()) });
     /// ```
-    pub fn incoming(&self) -> impl Stream<Item = io::Result<Async<TcpStream>>> + Send + Unpin + '_ {
-        Box::pin(stream::unfold(self, |listener| async move {
+    pub fn incoming(&self) -> impl Stream<Item = io::Result<Async<TcpStream>>> + Send + '_ {
+        stream::unfold(self, |listener| async move {
             let res = listener.accept().await.map(|(stream, _)| stream);
             Some((res, listener))
-        }))
+        })
     }
 }
 
@@ -1180,12 +1181,13 @@ impl Async<UnixListener> {
     ///
     /// ```no_run
     /// use async_io::Async;
-    /// use futures_lite::stream::StreamExt;
+    /// use futures_lite::{pin, stream::StreamExt};
     /// use std::os::unix::net::UnixListener;
     ///
     /// # futures_lite::future::block_on(async {
     /// let listener = Async::<UnixListener>::bind("/tmp/socket")?;
-    /// let mut incoming = listener.incoming();
+    /// let incoming = listener.incoming();
+    /// pin!(incoming);
     ///
     /// while let Some(stream) = incoming.next().await {
     ///     let stream = stream?;
@@ -1195,11 +1197,11 @@ impl Async<UnixListener> {
     /// ```
     pub fn incoming(
         &self,
-    ) -> impl Stream<Item = io::Result<Async<UnixStream>>> + Send + Unpin + '_ {
-        Box::pin(stream::unfold(self, |listener| async move {
+    ) -> impl Stream<Item = io::Result<Async<UnixStream>>> + Send + '_ {
+        stream::unfold(self, |listener| async move {
             let res = listener.accept().await.map(|(stream, _)| stream);
             Some((res, listener))
-        }))
+        })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,8 +334,10 @@ pub struct Async<T> {
     source: Arc<Source>,
 
     /// The inner I/O handle.
-    io: Option<Box<T>>,
+    io: Option<T>,
 }
+
+impl<T> Unpin for Async<T> {}
 
 #[cfg(unix)]
 impl<T: AsRawFd> Async<T> {
@@ -366,7 +368,7 @@ impl<T: AsRawFd> Async<T> {
     pub fn new(io: T) -> io::Result<Async<T>> {
         Ok(Async {
             source: Reactor::get().insert_io(io.as_raw_fd())?,
-            io: Some(Box::new(io)),
+            io: Some(io),
         })
     }
 }
@@ -407,7 +409,7 @@ impl<T: AsRawSocket> Async<T> {
     pub fn new(io: T) -> io::Result<Async<T>> {
         Ok(Async {
             source: Reactor::get().insert_io(io.as_raw_socket())?,
-            io: Some(Box::new(io)),
+            io: Some(io),
         })
     }
 }
@@ -473,7 +475,7 @@ impl<T> Async<T> {
     /// # std::io::Result::Ok(()) });
     /// ```
     pub fn into_inner(mut self) -> io::Result<T> {
-        let io = *self.io.take().unwrap();
+        let io = self.io.take().unwrap();
         Reactor::get().remove_io(&self.source)?;
         Ok(io)
     }

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -70,7 +70,7 @@ fn tcp_peek_read() -> io::Result<()> {
         stream.write_all(LOREM_IPSUM).await?;
 
         let mut buf = [0; 1024];
-        let mut incoming = listener.incoming();
+        let mut incoming = Box::pin(listener.incoming());
         let mut stream = incoming.next().await.unwrap()?;
 
         let n = stream.peek(&mut buf).await?;
@@ -168,7 +168,7 @@ fn udp_connect() -> io::Result<()> {
         stream.write_all(LOREM_IPSUM).await?;
 
         let mut buf = [0; 1024];
-        let mut incoming = listener.incoming();
+        let mut incoming = Box::pin(listener.incoming());
         let mut stream = incoming.next().await.unwrap()?;
 
         let n = stream.read(&mut buf).await?;


### PR DESCRIPTION
Warning: the second commit introduces a slight API break (the returned streams no longer implement `Unpin`). Perhaps you only want to take the first but not the second commit, or perhaps only release the second commit in the next API-breaking release.

### First commit

As far as I can see, the only reason for `Async<T>` to use a `Box<T>` internally was for the `Async<T>` to be `Unpin`, no matter whether `T` itself is `Unpin` or not. But you can achieve that by just explicitly asking for it:

```rust
impl<T> Unpin for Async<T> {}
```

As `Async<T>` never creates a `Pin<&mut T>` or anything like that (that would be useless — most likely `T` is not a `Future` or a `Stream`), it is completely fine to just implement `Unpin` for the aggregate type (`Async<T>`) even if one of the fields is `!Unpin`.

https://doc.rust-lang.org/std/pin/index.html#pinning-is-not-structural-for-field

### Second commit

Again, as far as I can see, the only reason to box the returned streams is for them to be `Unpin`. But in a lot of cases — such as when using stream combinators — it doesn't really matter whether the stream impls `Unpin` or not. It *does* matter when the caller wants to do

```rust
while let Some(item) = stream.next().await {
    ...
}
```
which is, admittedly, a common way to consume a stream in today's Rust (stream combinators are another common way), but it might become less important when we get native `async for` support. In the meantime, if the caller needs for the stream to be pinned, they can do so themselves, with `pin!()`, or by using `Box::pin()` themselves.

But it is a bit less convenient, and kind of breaks the API; that's the trade-off. I still think it's worth it because Rust is All About Avoiding Unnecessary Boxing, but you might disagree.