### PR TITLE
remove `libc` dependency on windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ readme = "README.md"
 concurrent-queue = "1.2.2"
 fastrand = "1.3.5"
 futures-lite = "1.4.0"
-libc = "0.2.78"
 log = "0.4.11"
 nb-connect = "1.0.0"
 once_cell = "1.4.1"
@@ -24,6 +23,9 @@ parking = "2.0.0"
 polling = "2.0.0"
 vec-arena = "1.0.0"
 waker-fn = "1.1.0"
+
+[target."cfg(unix)".dependencies]
+libc = "0.2.77"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = ["winsock2"] }


### PR DESCRIPTION
Like [in](https://github.com/stjepang/polling/blob/master/Cargo.toml#L23) `polling` we only need `libc` on unix systems