### PR TITLE
fix changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 # Version 1.1.7
 
-- Update `async-io` to v2.0.0
+- Update `polling` to v2.0.0
 
 # Version 1.1.6
 


### PR DESCRIPTION
I think this changelog entry is wrong because [the commit message](https://github.com/stjepang/async-io/commit/906de8e99a20a6dc227cb88e7d7aa741d957eb32) that bumped the `polling` version is `Update async-io` :smile: 